### PR TITLE
Fixed prototype pollution in mout

### DIFF
--- a/src/object/set.js
+++ b/src/object/set.js
@@ -4,6 +4,10 @@ define(['./namespace'], function (namespace) {
      * set "nested" object property
      */
     function set(obj, prop, val){
+        // prototype pollution mitigation
+        if(prop.includes('__proto__') || prop.includes('prototype') || prop.includes('constructor')) {
+            return false;
+        }
         var parts = (/^(.+)\.(.+)$/).exec(prop);
         if (parts){
             namespace(obj, parts[1])[parts[2]] = val;


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-mout

### ⚙️ Description *

*mout* is vulnerable to Prototype Pollution. This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `props` in `set` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `Yes! Its Polluted`.
```javascript
var mout = require("mout")
var obj = {}
console.log("Before : " + {}.polluted);
mout.object.set(obj,'__proto__.polluted','Yes! Its Polluted');
console.log("After : " + {}.polluted);
```

![image](https://user-images.githubusercontent.com/16708391/102101104-3c01f880-3e50-11eb-97c6-94e5953dcc57.png)



### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns `undefined` since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.

![image](https://user-images.githubusercontent.com/16708391/102101178-4e7c3200-3e50-11eb-9de4-eb2101a421b9.png)



### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `p` and no breaking changes are introduced. :)
